### PR TITLE
Fixed the Unity crash for multiple sound sources

### DIFF
--- a/NativeCode/Plugin_Spatializer.cpp
+++ b/NativeCode/Plugin_Spatializer.cpp
@@ -30,6 +30,8 @@ namespace Spatializer
 
 	const float GAINCORRECTION = 2.0f;
 
+	static int instanceCounter = 0;
+
 	class HRTFData
 	{
 
@@ -260,7 +262,12 @@ namespace Spatializer
         InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
 
 		// Load all SOFA files
-		LoadSOFAs(state);
+		if (0 == instanceCounter) {
+			LoadSOFAs(state);
+		}
+		
+		instanceCounter++;
+
         return UNITY_AUDIODSP_OK;
     }
 
@@ -268,8 +275,14 @@ namespace Spatializer
     {
         EffectData* data = state->GetEffectData<EffectData>();
         delete data;
+
+		instanceCounter--;
+		
 		// Free the memory from all HRTFs 
-		UnloadSOFAs();
+		if (0 == instanceCounter) {
+			UnloadSOFAs();
+		}
+		
         return UNITY_AUDIODSP_OK;
     }
 


### PR DESCRIPTION
The issue was mentioned in #7. 

Unity creates separate instances of the Spatializer plugin per each spatialized AudioSource in the scene, which means that the Spatializer::CreateCallback function is called everytime a new AudioSource is enabled/spatialization is switched on. At the same time, the plugin is designed in a manner where all audio sources share the same HRTF data, and said data is loaded in the CreateCallback function.

The error that we've all stumbled upon when trying to run the plugin with multiple sources was caused by trials of reloading the static shared HRTF data when new spatialized sources appeared in the scene. The existing source tried to read the HRTF, while the newly created source modified the contents of the structure, what caused the crash. 

The simple fix for that problem is to introduce a global counter of the plugin's instances and guard the process of loading HRTFs with it, thus force the HRTF data structure to be loaded only when creating the first instance of the plugin and unloaded only after the last spatialized source is removed. In this way we can avoid the destructive shared HRTF data modifications.