### PR TITLE
Compile, upload and release Windows DLL

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  push
+
+env:
+  SOLUTION_FILE_PATH: NativeCode\VisualStudio\AudioPluginSOFA.sln
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  Win64:
+    runs-on: windows-2022
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=x64 ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: SOFAlizer-for-Unity
+        path: "NativeCode/VisualStudio/build/Release/"
+
+    - name: GitHub pre-release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{secrets.GITHUB_TOKEN}}"
+        automatic_release_tag: "latest"
+        prerelease: true
+        title: "SOFAlizer for Unity"
+        files: "NativeCode/VisualStudio/build/Release/*"

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/upload-artifact@v3.1.1
       with:
         name: SOFAlizer-for-Unity
-        path: "NativeCode/VisualStudio/build/Release/"
+        path: "NativeCode/VisualStudio/build/Release/AudioPluginSOFA.dll"
 
     - name: GitHub pre-release
       uses: "marvinpinto/action-automatic-releases@latest"
@@ -38,4 +38,4 @@ jobs:
         automatic_release_tag: "latest"
         prerelease: true
         title: "SOFAlizer for Unity"
-        files: "NativeCode/VisualStudio/build/Release/*"
+        files: "NativeCode/VisualStudio/build/Release/AudioPluginSOFA.dll"

--- a/NativeCode/VisualStudio/AudioPluginDemo.vcproj
+++ b/NativeCode/VisualStudio/AudioPluginDemo.vcproj
@@ -95,7 +95,7 @@
 			IntermediateDirectory="build/$(ConfigurationName)"
 			ConfigurationType="2"
 			CharacterSet="0"
-			WholeProgramOptimization="1"
+			WholeProgramOptimization="0"
 			>
 			<Tool
 				Name="VCPreBuildEventTool"

--- a/NativeCode/VisualStudio/AudioPluginDemo.vcxproj
+++ b/NativeCode/VisualStudio/AudioPluginDemo.vcxproj
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
This adds a GitHub Actions workflow to compile the Release x64 DLL on every commit push and upload the artifact to the [workflow](https://github.com/ThreeDeeJay/SOFAlizer-for-Unity/actions/runs/3604119588) and [(pre)release](https://github.com/ThreeDeeJay/SOFAlizer-for-Unity/releases), (re)using the `latest` tag.

Just a heads up though, I had to disable `WholeProgramOptimization` in dc6a2abafcd1d485220d1a3d4ab9d48e0e442b14 to fix a [compilation error](https://github.com/ThreeDeeJay/SOFAlizer-for-Unity/actions/runs/3604039674/jobs/6072955022#step:5:87).
Perhaps there is a better solution because I don't know the side effects of disabling that flag.

Also, I haven't really tested the DLL. I just built it to try replacing the spatializer in already compiled/shipped Unity games with this so I can get spatial audio using my HRTF.
For that, I opened `globalgamemanagers` in [UABE](https://github.com/SeriousCache/UABE/releases/tag/v3.0-beta1) to set `m_SpatializerPlugin` to `SOFA Spatializer` and copied `AudioPluginSOFA.dll` to `GameName_Data/Plugins/`.
![image](https://user-images.githubusercontent.com/71472458/205443289-e2109c52-839d-43ba-93d3-40ec49fa515c.png)

However, I'm yet to succeed. I think I also need to update other assets to hack SOFAlizer into the game, but I'm not sure which or how. I just know this method works for [adding VR support in some games](https://www.notion.so/beastsaber/How-To-Force-Any-Unity-Game-to-Run-In-Native-VR-Mode-cf8c50f66f2740d5b692db786a8386a1).